### PR TITLE
Expose problem report daily totals for a given path

### DIFF
--- a/fixtures/performance_platform_problem_reports_response.json
+++ b/fixtures/performance_platform_problem_reports_response.json
@@ -1,0 +1,23 @@
+{
+    "data": [
+        {
+            "_count": 0,
+            "_end_at": "2014-07-26T00:00:00+00:00",
+            "_start_at": "2014-07-25T00:00:00+00:00",
+            "total:sum": null
+        },
+        {
+            "_count": 0,
+            "_end_at": "2014-07-27T00:00:00+00:00",
+            "_start_at": "2014-07-26T00:00:00+00:00",
+            "total:sum": null
+        },
+        {
+            "_count": 1,
+            "_end_at": "2014-07-28T00:00:00+00:00",
+            "_start_at": "2014-07-27T00:00:00+00:00",
+            "total:sum": 16
+        }
+    ],
+    "warning": "Warning: This data-set is unpublished. Data may be subject to change or be inaccurate."
+}

--- a/info_test.go
+++ b/info_test.go
@@ -15,7 +15,7 @@ import (
 
 var _ = Describe("Info", func() {
 	var (
-		contentAPIResponse, needAPIResponse, pageviewsResponse, searchesResponse, termsResponse string
+		contentAPIResponse, needAPIResponse, pageviewsResponse, searchesResponse, problemReportsResponse, termsResponse string
 
 		testServer, testContentAPI, testNeedAPI, testPerformanceAPI *httptest.Server
 
@@ -57,6 +57,9 @@ var _ = Describe("Info", func() {
 			} else if strings.Contains(r.URL.Path, "search-terms") {
 				w.WriteHeader(http.StatusOK)
 				fmt.Fprintln(w, searchesResponse)
+			} else if strings.Contains(r.URL.Path, "page-contacts") {
+				w.WriteHeader(http.StatusOK)
+				fmt.Fprintln(w, problemReportsResponse)
 			} else {
 				w.WriteHeader(http.StatusNotFound)
 			}
@@ -106,12 +109,14 @@ var _ = Describe("Info", func() {
 			needAPIResponseBytes, _ := ioutil.ReadFile("fixtures/need_api_response.json")
 			pageviewsResponseBytes, _ := ioutil.ReadFile("fixtures/performance_platform_pageviews_response.json")
 			searchesResponseBytes, _ := ioutil.ReadFile("fixtures/performance_platform_searches_response.json")
+			problemReportsResponseBytes, _ := ioutil.ReadFile("fixtures/performance_platform_problem_reports_response.json")
 			termsResponseBytes, _ := ioutil.ReadFile("fixtures/performance_platform_terms_response.json")
 
 			contentAPIResponse = string(contentAPIResponseBytes)
 			needAPIResponse = string(needAPIResponseBytes)
 			pageviewsResponse = string(pageviewsResponseBytes)
 			searchesResponse = string(searchesResponseBytes)
+			problemReportsResponse = string(problemReportsResponseBytes)
 			termsResponse = string(termsResponseBytes)
 		})
 
@@ -138,6 +143,9 @@ var _ = Describe("Info", func() {
 			Expect(metadata.Performance.Searches).To(HaveLen(3))
 			Expect(metadata.Performance.Searches[0].Value).To(Equal(0))
 			Expect(metadata.Performance.Searches[2].Value).To(Equal(16))
+			Expect(metadata.Performance.ProblemReports).To(HaveLen(3))
+			Expect(metadata.Performance.ProblemReports[0].Value).To(Equal(0))
+			Expect(metadata.Performance.ProblemReports[2].Value).To(Equal(16))
 			Expect(metadata.Performance.SearchTerms).To(HaveLen(6))
 			Expect(metadata.Performance.SearchTerms[1].Keyword).To(Equal("s2s"))
 			Expect(metadata.Performance.SearchTerms[1].Searches).To(HaveLen(1))

--- a/performance_platform/statistics_test.go
+++ b/performance_platform/statistics_test.go
@@ -102,6 +102,20 @@ var _ = Describe("Statistics", func() {
 ]
 }`),
 				),
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest("GET", "/data/govuk-info/page-contacts"),
+					ghttp.RespondWith(http.StatusOK, `
+{
+"data": [
+	{
+		"_count": 4,
+		"_end_at": "2014-09-03T00:00:00+00:00",
+		"_start_at": "2014-09-02T00:00:00+00:00",
+		"total:sum": 71
+	}
+]
+}`),
+				),
 			)
 
 			statistics, err := client.SlugStatistics("/foo")
@@ -110,8 +124,10 @@ var _ = Describe("Statistics", func() {
 			Expect(len(statistics.PageViews)).To(Equal(1))
 			Expect(len(statistics.Searches)).To(Equal(1))
 			Expect(len(statistics.SearchTerms)).To(Equal(3))
+			Expect(len(statistics.ProblemReports)).To(Equal(1))
 			Expect(statistics.PageViews[0].Value).To(Equal(25931))
 			Expect(statistics.Searches[0].Value).To(Equal(71))
+			Expect(statistics.ProblemReports[0].Value).To(Equal(71))
 
 			pageViewTimestamp, err := time.Parse(time.RFC3339, "2014-07-03T00:00:00+00:00")
 			Expect(err).To(BeNil())


### PR DESCRIPTION
eg

```
{
  artefact: [...],
  performance: {
    page_views: [...],
    searches: [...],
    problem_reports: [
      {
        timestamp: "2014-08-20T00:00:00Z",
        value: 3
      },
      {
        timestamp: "2014-08-21T00:00:00Z",
        value: 2
      },
      {
        timestamp: "2014-08-22T00:00:00Z",
        value: 15
      }
    ],
    search_terms: [...]
  }
}
```
