### PR TITLE
When there are no needs, return "needs":[]

### DIFF
--- a/fixtures/content_api_response_without_need_ids.json
+++ b/fixtures/content_api_response_without_need_ids.json
@@ -1,0 +1,15 @@
+{
+  "id": "https://www.gov.uk/api/driving-licence-fees.json",
+  "web_url": "https://www.gov.uk/driving-licence-fees",
+  "title": "Driving licence fees",
+  "format": "answer",
+  "updated_at": "2014-06-27T14:21:48+01:00",
+  "details": {
+    "need_ids": [],
+    "language": "en",
+    "body": "foo"
+  },
+  "_response_info": {
+    "status": "ok"
+  }
+}

--- a/info_test.go
+++ b/info_test.go
@@ -152,6 +152,38 @@ var _ = Describe("Info", func() {
 		})
 	})
 
+	Describe("fetching a slug without need_ids", func() {
+		BeforeEach(func() {
+			contentAPIResponseBytes, _ := ioutil.ReadFile("fixtures/content_api_response_without_need_ids.json")
+			pageviewsResponseBytes, _ := ioutil.ReadFile("fixtures/performance_platform_pageviews_response.json")
+			searchesResponseBytes, _ := ioutil.ReadFile("fixtures/performance_platform_searches_response.json")
+			problemReportsResponseBytes, _ := ioutil.ReadFile("fixtures/performance_platform_problem_reports_response.json")
+			termsResponseBytes, _ := ioutil.ReadFile("fixtures/performance_platform_terms_response.json")
+
+			contentAPIResponse = string(contentAPIResponseBytes)
+			pageviewsResponse = string(pageviewsResponseBytes)
+			searchesResponse = string(searchesResponseBytes)
+			problemReportsResponse = string(problemReportsResponseBytes)
+			termsResponse = string(termsResponseBytes)
+		})
+
+		It("returns a metadata response with the an empty Needs array", func() {
+			response, err := getSlug(testServer.URL, "dummy-slug")
+			Expect(err).To(BeNil())
+			Expect(response.StatusCode).To(Equal(http.StatusOK))
+
+			body, err := readResponseBody(response)
+			Expect(err).To(BeNil())
+
+			metadata, err := ParseMetadataResponse([]byte(body))
+			Expect(err).To(BeNil())
+
+			Expect(metadata.ResponseInfo.Status).To(Equal("ok"))
+
+			Expect(metadata.Needs).To(HaveLen(0))
+		})
+	})
+
 	Describe("querying for a slug that doesn't exist", func() {
 		BeforeEach(func() {
 			testContentAPI = testHandlerServer(func(w http.ResponseWriter, r *http.Request) {

--- a/main.go
+++ b/main.go
@@ -41,7 +41,7 @@ func HealthCheckHandler(w http.ResponseWriter, r *http.Request) {
 
 func InfoHandler(contentAPI, needAPI, performanceAPI string, config *Config) func(http.ResponseWriter, *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
-		var needs []*need_api.Need
+		var needs []*need_api.Need = make([]*need_api.Need, 0)
 
 		slug := r.URL.Path[len("/info"):]
 


### PR DESCRIPTION
Before this change, the API returns `"needs": null`
