### PR TITLE
Return page path with the metrics

### DIFF
--- a/fixtures/performance_platform_pageviews_response.json
+++ b/fixtures/performance_platform_pageviews_response.json
@@ -1,16 +1,21 @@
 {
     "data": [
         {
-            "_count": 1,
-            "_end_at": "2014-07-04T00:00:00+00:00",
-            "_start_at": "2014-07-03T00:00:00+00:00",
-            "uniquePageviews:sum": 25931
-        },
-        {
-            "_count": 1,
-            "_end_at": "2014-07-05T00:00:00+00:00",
-            "_start_at": "2014-07-04T00:00:00+00:00",
-            "uniquePageviews:sum": 22339
+            "pagePath": "/dummy-slug",
+            "values": [
+              {
+                "_count": 1,
+                "_end_at": "2014-07-04T00:00:00+00:00",
+                "_start_at": "2014-07-03T00:00:00+00:00",
+                "uniquePageviews:sum": 25931
+              },
+              {
+                "_count": 1,
+                "_end_at": "2014-07-05T00:00:00+00:00",
+                "_start_at": "2014-07-04T00:00:00+00:00",
+                "uniquePageviews:sum": 22339
+              }
+            ]
         }
     ],
     "warning": "Warning: This data-set is unpublished. Data may be subject to change or be inaccurate."

--- a/fixtures/performance_platform_problem_reports_response.json
+++ b/fixtures/performance_platform_problem_reports_response.json
@@ -1,23 +1,28 @@
 {
-    "data": [
+  "data": [
+    {
+      "pagePath": "/dummy-slug",
+      "values": [
         {
-            "_count": 0,
-            "_end_at": "2014-07-26T00:00:00+00:00",
-            "_start_at": "2014-07-25T00:00:00+00:00",
-            "total:sum": null
+          "_count": 0,
+          "_end_at": "2014-07-26T00:00:00+00:00",
+          "_start_at": "2014-07-25T00:00:00+00:00",
+          "total:sum": null
         },
         {
-            "_count": 0,
-            "_end_at": "2014-07-27T00:00:00+00:00",
-            "_start_at": "2014-07-26T00:00:00+00:00",
-            "total:sum": null
+          "_count": 0,
+          "_end_at": "2014-07-27T00:00:00+00:00",
+          "_start_at": "2014-07-26T00:00:00+00:00",
+          "total:sum": null
         },
         {
-            "_count": 1,
-            "_end_at": "2014-07-28T00:00:00+00:00",
-            "_start_at": "2014-07-27T00:00:00+00:00",
-            "total:sum": 16
+          "_count": 1,
+          "_end_at": "2014-07-28T00:00:00+00:00",
+          "_start_at": "2014-07-27T00:00:00+00:00",
+          "total:sum": 16
         }
-    ],
-    "warning": "Warning: This data-set is unpublished. Data may be subject to change or be inaccurate."
+      ]
+    }
+  ],
+  "warning": "Warning: This data-set is unpublished. Data may be subject to change or be inaccurate."
 }

--- a/fixtures/performance_platform_searches_response.json
+++ b/fixtures/performance_platform_searches_response.json
@@ -1,23 +1,28 @@
 {
-    "data": [
+  "data": [
+    {
+      "pagePath": "/dummy-slug",
+      "values": [
         {
-            "_count": 0,
-            "_end_at": "2014-07-26T00:00:00+00:00",
-            "_start_at": "2014-07-25T00:00:00+00:00",
-            "searchUniques:sum": null
+          "_count": 0,
+          "_end_at": "2014-07-26T00:00:00+00:00",
+          "_start_at": "2014-07-25T00:00:00+00:00",
+          "searchUniques:sum": null
         },
         {
-            "_count": 0,
-            "_end_at": "2014-07-27T00:00:00+00:00",
-            "_start_at": "2014-07-26T00:00:00+00:00",
-            "searchUniques:sum": null
+          "_count": 0,
+          "_end_at": "2014-07-27T00:00:00+00:00",
+          "_start_at": "2014-07-26T00:00:00+00:00",
+          "searchUniques:sum": null
         },
         {
-            "_count": 1,
-            "_end_at": "2014-07-28T00:00:00+00:00",
-            "_start_at": "2014-07-27T00:00:00+00:00",
-            "searchUniques:sum": 16
+          "_count": 1,
+          "_end_at": "2014-07-28T00:00:00+00:00",
+          "_start_at": "2014-07-27T00:00:00+00:00",
+          "searchUniques:sum": 16
         }
-    ],
-    "warning": "Warning: This data-set is unpublished. Data may be subject to change or be inaccurate."
+      ]
+    }
+  ],
+  "warning": "Warning: This data-set is unpublished. Data may be subject to change or be inaccurate."
 }

--- a/info_test.go
+++ b/info_test.go
@@ -51,7 +51,7 @@ var _ = Describe("Info", func() {
 				w.WriteHeader(http.StatusOK)
 				fmt.Fprintln(w, pageviewsResponse)
 			} else if strings.Contains(r.URL.Path, "search-terms") &&
-				strings.Contains(r.URL.RawQuery, "group_by") {
+			  r.URL.Query().Get("group_by") == "searchKeyword" {
 				w.WriteHeader(http.StatusOK)
 				fmt.Fprintln(w, termsResponse)
 			} else if strings.Contains(r.URL.Path, "search-terms") {

--- a/performance_platform/statistics.go
+++ b/performance_platform/statistics.go
@@ -36,6 +36,11 @@ type PageViewsForDate struct {
 	PageViews float32   `json:"uniquePageviews:sum"`
 }
 
+type ProblemReportsForDate struct {
+	Timestamp      time.Time `json:"_start_at"`
+	ProblemReports float32   `json:"total:sum"`
+}
+
 func (terms SearchTerms) Len() int           { return len(terms) }
 func (terms SearchTerms) Swap(i, j int)      { terms[i], terms[j] = terms[j], terms[i] }
 func (terms SearchTerms) Less(i, j int) bool { return terms[i].TotalSearches > terms[j].TotalSearches }
@@ -119,6 +124,7 @@ func SlugStatistics(client performanceclient.DataClient, slug string) (*Statisti
 		if problemReportsResponse, err := client.Fetch("govuk-info", "page-contacts", performanceclient.QueryParams{
 			FilterBy: []string{"pagePath:" + slug},
 			Collect:  []string{"total:sum"},
+			GroupBy:  "pagePath",
 			Duration: 42,
 			Period:   "day",
 			EndAt:    now.BeginningOfDay().UTC(),
@@ -194,22 +200,26 @@ func parseSearches(response *performanceclient.BackdropResponse) ([]Statistic, e
 }
 
 func parseProblemReports(response *performanceclient.BackdropResponse) ([]Statistic, error) {
-	var data []struct {
-		Timestamp      time.Time `json:"_start_at"`
-		ProblemReports float32   `json:"total:sum"`
+	var datasetsPerPath []struct {
+		Path   string                  `json:"pagePath"`
+		Values []ProblemReportsForDate `json:"values"`
 	}
 
-	err := json.Unmarshal(response.Data, &data)
+	err := json.Unmarshal(response.Data, &datasetsPerPath)
 
 	if err != nil {
 		return []Statistic{}, err
 	}
 
-	statistics := make([]Statistic, len(data))
-	for i, datum := range data {
-		statistics[i] = Statistic{
-			Timestamp: datum.Timestamp,
-			Value:     int(datum.ProblemReports),
+	statistics := make([]Statistic, 0)
+	for _, datasetPerPath := range datasetsPerPath {
+		for _, datum := range datasetPerPath.Values {
+			statistic := Statistic{
+				Path:      datasetPerPath.Path,
+				Timestamp: datum.Timestamp,
+				Value:     int(datum.ProblemReports),
+			}
+			statistics = append(statistics, statistic)
 		}
 	}
 	return statistics, nil

--- a/performance_platform/statistics.go
+++ b/performance_platform/statistics.go
@@ -26,8 +26,14 @@ type SearchTerm struct {
 }
 
 type Statistic struct {
+	Path      string    `json:"path"`
 	Timestamp time.Time `json:"timestamp"`
 	Value     int       `json:"value"`
+}
+
+type PageViewsForDate struct {
+	Timestamp time.Time `json:"_start_at"`
+	PageViews float32   `json:"uniquePageviews:sum"`
 }
 
 func (terms SearchTerms) Len() int           { return len(terms) }
@@ -49,6 +55,7 @@ func SlugStatistics(client performanceclient.DataClient, slug string) (*Statisti
 			performanceclient.QueryParams{
 				FilterBy: []string{"pagePath:" + slug},
 				Collect:  []string{"uniquePageviews:sum"},
+				GroupBy:  "pagePath",
 				Duration: 42,
 				Period:   "day",
 				EndAt:    now.BeginningOfDay().UTC(),
@@ -139,22 +146,26 @@ func SlugStatistics(client performanceclient.DataClient, slug string) (*Statisti
 }
 
 func parsePageViews(response *performanceclient.BackdropResponse) ([]Statistic, error) {
-	var data []struct {
-		Timestamp time.Time `json:"_start_at"`
-		PageViews float32   `json:"uniquePageviews:sum"`
+	var datasetsPerPath []struct {
+		Path   string             `json:"pagePath"`
+		Values []PageViewsForDate `json:"values"`
 	}
 
-	err := json.Unmarshal(response.Data, &data)
+	err := json.Unmarshal(response.Data, &datasetsPerPath)
 
 	if err != nil {
 		return []Statistic{}, err
 	}
 
-	statistics := make([]Statistic, len(data))
-	for i, datum := range data {
-		statistics[i] = Statistic{
-			Timestamp: datum.Timestamp,
-			Value:     int(datum.PageViews),
+	statistics := make([]Statistic, 0)
+	for _, datasetPerPath := range datasetsPerPath {
+		for _, datum := range datasetPerPath.Values {
+			statistic := Statistic{
+				Path:      datasetPerPath.Path,
+				Timestamp: datum.Timestamp,
+				Value:     int(datum.PageViews),
+			}
+			statistics = append(statistics, statistic)
 		}
 	}
 	return statistics, nil

--- a/performance_platform/statistics_test.go
+++ b/performance_platform/statistics_test.go
@@ -58,12 +58,17 @@ var _ = Describe("Statistics", func() {
 							ghttp.RespondWith(http.StatusOK, `
 {
 "data": [
-  {
-    "_count": 4,
-    "_end_at": "2014-09-03T00:00:00+00:00",
-    "_start_at": "2014-09-02T00:00:00+00:00",
-    "searchUniques:sum": 71
-  }
+	{
+		"pagePath": "/tax-disc",
+		"values": [
+			{
+				"_count": 4,
+				"_end_at": "2014-09-03T00:00:00+00:00",
+				"_start_at": "2014-09-02T00:00:00+00:00",
+				"searchUniques:sum": 71
+			}
+		]
+	}
 ]
 }`)(w, r)
 						} else {
@@ -141,6 +146,7 @@ var _ = Describe("Statistics", func() {
 			Expect(statistics.PageViews[0].Value).To(Equal(25931))
 			Expect(statistics.PageViews[0].Path).To(Equal("/tax-disc"))
 			Expect(statistics.Searches[0].Value).To(Equal(71))
+			Expect(statistics.Searches[0].Path).To(Equal("/tax-disc"))
 			Expect(statistics.ProblemReports[0].Value).To(Equal(71))
 			Expect(statistics.ProblemReports[0].Path).To(Equal("/tax-disc"))
 

--- a/performance_platform/statistics_test.go
+++ b/performance_platform/statistics_test.go
@@ -37,10 +37,15 @@ var _ = Describe("Statistics", func() {
 {
 "data": [
   {
-    "_count": 1,
-    "_end_at": "2014-07-04T00:00:00+00:00",
-    "_start_at": "2014-07-03T00:00:00+00:00",
-    "uniquePageviews:sum": 25931
+    "pagePath": "/tax-disc",
+    "values": [
+      {
+        "_count": 1,
+        "_end_at": "2014-07-04T00:00:00+00:00",
+        "_start_at": "2014-07-03T00:00:00+00:00",
+        "uniquePageviews:sum": 25931
+      }
+    ]
   }
 ]
 }`)))
@@ -129,6 +134,7 @@ var _ = Describe("Statistics", func() {
 			Expect(len(statistics.SearchTerms)).To(Equal(3))
 			Expect(len(statistics.ProblemReports)).To(Equal(1))
 			Expect(statistics.PageViews[0].Value).To(Equal(25931))
+			Expect(statistics.PageViews[0].Path).To(Equal("/tax-disc"))
 			Expect(statistics.Searches[0].Value).To(Equal(71))
 			Expect(statistics.ProblemReports[0].Value).To(Equal(71))
 

--- a/performance_platform/statistics_test.go
+++ b/performance_platform/statistics_test.go
@@ -118,10 +118,15 @@ var _ = Describe("Statistics", func() {
 {
 "data": [
 	{
-		"_count": 4,
-		"_end_at": "2014-09-03T00:00:00+00:00",
-		"_start_at": "2014-09-02T00:00:00+00:00",
-		"total:sum": 71
+		"pagePath": "/tax-disc",
+		"values": [
+			{
+				"_count": 4,
+				"_end_at": "2014-09-03T00:00:00+00:00",
+				"_start_at": "2014-09-02T00:00:00+00:00",
+				"total:sum": 71
+			}
+		]
 	}
 ]
 }`)))
@@ -137,6 +142,7 @@ var _ = Describe("Statistics", func() {
 			Expect(statistics.PageViews[0].Path).To(Equal("/tax-disc"))
 			Expect(statistics.Searches[0].Value).To(Equal(71))
 			Expect(statistics.ProblemReports[0].Value).To(Equal(71))
+			Expect(statistics.ProblemReports[0].Path).To(Equal("/tax-disc"))
 
 			pageViewTimestamp, err := time.Parse(time.RFC3339, "2014-07-03T00:00:00+00:00")
 			Expect(err).To(BeNil())


### PR DESCRIPTION
This is going to be useful when there are metrics returned for multiple page paths in the same `metadata-api` response (for multi-part content).