### PR TITLE
Return data for multi-part formats

### DIFF
--- a/Gomfile
+++ b/Gomfile
@@ -1,4 +1,4 @@
-gom 'github.com/alphagov/performanceplatform-client.go', :commit => '4f87c98640f2b28411c0d1d51baf295be42675f8'
+gom 'github.com/alphagov/performanceplatform-client.go', :commit => '6b388883f3e3cf2a864aeb335ce36e10f0e7a60d'
 gom 'github.com/Sirupsen/logrus', :commit => '965349de21e7b1e9e80b6ae02e093f1522516ef3'
 gom 'github.com/codegangsta/negroni', :commit => 'c64702ca03d0f858ab7866638b69e85f0d4c6ee7'
 gom 'github.com/google/go-querystring/query', :commit => '30f7a39f4a218feb5325f3aebc60c32a572a8274'

--- a/fixtures/content_api_response_with_parts.json
+++ b/fixtures/content_api_response_with_parts.json
@@ -1,0 +1,29 @@
+{
+  "id": "https://www.gov.uk/api/driving-licence-fees.json",
+  "web_url": "https://www.gov.uk/driving-licence-fees",
+  "title": "Driving licence fees",
+  "format": "answer",
+  "updated_at": "2014-06-27T14:21:48+01:00",
+  "details": {
+    "need_ids": ["100567"],
+    "language": "en",
+    "body": "foo",
+    "parts": [
+      {
+        "web_url": "https://www.gov.uk/housing-benefit/overview",
+        "slug": "overview",
+        "order": 1,
+        "title": "Overview"
+      },
+      {
+        "web_url": "https://www.gov.uk/housing-benefit/what-youll-get",
+        "slug": "what-youll-get",
+        "order": 2,
+        "title": "What you'll get"
+      }
+    ]
+  },
+  "_response_info": {
+    "status": "ok"
+  }
+}

--- a/fixtures/performance_platform_pageviews_multipart_response.json
+++ b/fixtures/performance_platform_pageviews_multipart_response.json
@@ -1,0 +1,39 @@
+{
+    "data": [
+        {
+            "pagePath": "/dummy-slug",
+            "values": [
+              {
+                "_count": 1,
+                "_end_at": "2014-07-04T00:00:00+00:00",
+                "_start_at": "2014-07-03T00:00:00+00:00",
+                "uniquePageviews:sum": 25931
+              },
+              {
+                "_count": 1,
+                "_end_at": "2014-07-05T00:00:00+00:00",
+                "_start_at": "2014-07-04T00:00:00+00:00",
+                "uniquePageviews:sum": 22339
+              }
+            ]
+        },
+        {
+            "pagePath": "/dummy-slug/1",
+            "values": [
+              {
+                "_count": 1,
+                "_end_at": "2014-07-04T00:00:00+00:00",
+                "_start_at": "2014-07-03T00:00:00+00:00",
+                "uniquePageviews:sum": 24335
+              },
+              {
+                "_count": 1,
+                "_end_at": "2014-07-05T00:00:00+00:00",
+                "_start_at": "2014-07-04T00:00:00+00:00",
+                "uniquePageviews:sum": 27697
+              }
+            ]
+        }
+    ],
+    "warning": "Warning: This data-set is unpublished. Data may be subject to change or be inaccurate."
+}

--- a/fixtures/performance_platform_problem_reports_multipart_response.json
+++ b/fixtures/performance_platform_problem_reports_multipart_response.json
@@ -1,0 +1,51 @@
+{
+  "data": [
+    {
+      "pagePath": "/dummy-slug",
+      "values": [
+        {
+          "_count": 0,
+          "_end_at": "2014-07-26T00:00:00+00:00",
+          "_start_at": "2014-07-25T00:00:00+00:00",
+          "total:sum": null
+        },
+        {
+          "_count": 0,
+          "_end_at": "2014-07-27T00:00:00+00:00",
+          "_start_at": "2014-07-26T00:00:00+00:00",
+          "total:sum": null
+        },
+        {
+          "_count": 1,
+          "_end_at": "2014-07-28T00:00:00+00:00",
+          "_start_at": "2014-07-27T00:00:00+00:00",
+          "total:sum": 16
+        }
+      ]
+    },
+    {
+      "pagePath": "/dummy-slug/second-page",
+      "values": [
+        {
+          "_count": 0,
+          "_end_at": "2014-07-26T00:00:00+00:00",
+          "_start_at": "2014-07-25T00:00:00+00:00",
+          "total:sum": 1
+        },
+        {
+          "_count": 0,
+          "_end_at": "2014-07-27T00:00:00+00:00",
+          "_start_at": "2014-07-26T00:00:00+00:00",
+          "total:sum": 0
+        },
+        {
+          "_count": 1,
+          "_end_at": "2014-07-28T00:00:00+00:00",
+          "_start_at": "2014-07-27T00:00:00+00:00",
+          "total:sum": 16
+        }
+      ]
+    }
+  ],
+  "warning": "Warning: This data-set is unpublished. Data may be subject to change or be inaccurate."
+}

--- a/fixtures/performance_platform_searches_multipart_response.json
+++ b/fixtures/performance_platform_searches_multipart_response.json
@@ -1,0 +1,51 @@
+{
+  "data": [
+    {
+      "pagePath": "/dummy-slug",
+      "values": [
+        {
+          "_count": 0,
+          "_end_at": "2014-07-26T00:00:00+00:00",
+          "_start_at": "2014-07-25T00:00:00+00:00",
+          "searchUniques:sum": null
+        },
+        {
+          "_count": 0,
+          "_end_at": "2014-07-27T00:00:00+00:00",
+          "_start_at": "2014-07-26T00:00:00+00:00",
+          "searchUniques:sum": null
+        },
+        {
+          "_count": 1,
+          "_end_at": "2014-07-28T00:00:00+00:00",
+          "_start_at": "2014-07-27T00:00:00+00:00",
+          "searchUniques:sum": 16
+        }
+      ]
+    },
+    {
+      "pagePath": "/dummy-slug/123",
+      "values": [
+        {
+          "_count": 0,
+          "_end_at": "2014-07-26T00:00:00+00:00",
+          "_start_at": "2014-07-25T00:00:00+00:00",
+          "searchUniques:sum": 0
+        },
+        {
+          "_count": 0,
+          "_end_at": "2014-07-27T00:00:00+00:00",
+          "_start_at": "2014-07-26T00:00:00+00:00",
+          "searchUniques:sum": null
+        },
+        {
+          "_count": 1,
+          "_end_at": "2014-07-28T00:00:00+00:00",
+          "_start_at": "2014-07-27T00:00:00+00:00",
+          "searchUniques:sum": 16
+        }
+      ]
+    }
+  ],
+  "warning": "Warning: This data-set is unpublished. Data may be subject to change or be inaccurate."
+}

--- a/main.go
+++ b/main.go
@@ -77,7 +77,8 @@ func InfoHandler(contentAPI, needAPI, performanceAPI string, config *Config) fun
 
 		performanceStart := time.Now()
 		ppClient := performanceclient.NewDataClient(performanceAPI, logging)
-		performance, err := performance_platform.SlugStatistics(ppClient, slug)
+		is_multipart := (len(artefact.Details.Parts) != 0)
+		performance, err := performance_platform.SlugStatistics(ppClient, slug, is_multipart)
 		statsDTiming("performance", performanceStart, time.Now())
 		if err != nil {
 			renderError(w, http.StatusInternalServerError, "Performance: "+err.Error())

--- a/performance_platform/statistics.go
+++ b/performance_platform/statistics.go
@@ -65,7 +65,7 @@ func SlugStatistics(client performanceclient.DataClient, slug string) (*Statisti
 			performanceclient.QueryParams{
 				FilterBy: []string{"pagePath:" + slug},
 				Collect:  []string{"uniquePageviews:sum"},
-				GroupBy:  "pagePath",
+				GroupBy:  []string{"pagePath"},
 				Duration: 42,
 				Period:   "day",
 				EndAt:    now.BeginningOfDay().UTC(),
@@ -85,7 +85,7 @@ func SlugStatistics(client performanceclient.DataClient, slug string) (*Statisti
 		if searchesResponse, err := client.Fetch("govuk-info", "search-terms", performanceclient.QueryParams{
 			FilterBy: []string{"pagePath:" + slug},
 			Collect:  []string{"searchUniques:sum"},
-			GroupBy:  "pagePath",
+			GroupBy:  []string{"pagePath"},
 			Duration: 42,
 			Period:   "day",
 			EndAt:    now.BeginningOfDay().UTC(),
@@ -104,7 +104,7 @@ func SlugStatistics(client performanceclient.DataClient, slug string) (*Statisti
 
 		if searchTermsResponse, err := client.Fetch("govuk-info", "search-terms", performanceclient.QueryParams{
 			FilterBy: []string{"pagePath:" + slug},
-			GroupBy:  "searchKeyword",
+			GroupBy:  []string{"searchKeyword"},
 			Collect:  []string{"searchUniques:sum"},
 			Duration: 42,
 			Period:   "day",
@@ -130,7 +130,7 @@ func SlugStatistics(client performanceclient.DataClient, slug string) (*Statisti
 		if problemReportsResponse, err := client.Fetch("govuk-info", "page-contacts", performanceclient.QueryParams{
 			FilterBy: []string{"pagePath:" + slug},
 			Collect:  []string{"total:sum"},
-			GroupBy:  "pagePath",
+			GroupBy:  []string{"pagePath"},
 			Duration: 42,
 			Period:   "day",
 			EndAt:    now.BeginningOfDay().UTC(),

--- a/performance_platform/statistics_test.go
+++ b/performance_platform/statistics_test.go
@@ -136,7 +136,7 @@ var _ = Describe("Statistics", func() {
 ]
 }`)))
 
-			statistics, err := SlugStatistics(client, "/foo")
+			statistics, err := SlugStatistics(client, "/foo", false)
 			Expect(err).To(BeNil())
 			Expect(statistics).ToNot(BeNil())
 			Expect(len(statistics.PageViews)).To(Equal(1))
@@ -171,6 +171,176 @@ var _ = Describe("Statistics", func() {
 			Expect(statistics.SearchTerms[0].Searches[0].Value).To(Equal(126))
 			Expect(statistics.SearchTerms[0].Searches[0].Timestamp).To(Equal(searchesTimestamp))
 		})
+
+	})
+
+	Describe("SlugStatisticsMultiPartFormat", func() {
+		It("Should return formatted data for a multi-part format", func() {
+			server.RouteToHandler("GET", "/data/govuk-info/page-statistics",
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest("GET", "/data/govuk-info/page-statistics"),
+					ghttp.RespondWith(http.StatusOK, `
+{
+"data": [
+  {
+    "pagePath": "/tax-disc",
+    "values": [
+      {
+        "_count": 1,
+        "_end_at": "2014-07-03T00:00:00+00:00",
+        "_start_at": "2014-07-02T00:00:00+00:00",
+        "uniquePageviews:sum": 25931
+      }
+    ]
+  },
+  {
+    "pagePath": "/tax-disc/page2",
+    "values": [
+      {
+        "_count": 1,
+        "_end_at": "2014-07-03T00:00:00+00:00",
+        "_start_at": "2014-07-02T00:00:00+00:00",
+        "uniquePageviews:sum": 25735
+      }
+    ]
+  }
+]
+}`)))
+
+			server.RouteToHandler("GET", "/data/govuk-info/search-terms",
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest("GET", "/data/govuk-info/search-terms"),
+					http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+						if r.URL.Query().Get("group_by") != "searchKeyword" {
+							ghttp.RespondWith(http.StatusOK, `
+{
+"data": [
+	{
+		"pagePath": "/tax-disc",
+		"values": [
+			{
+				"_count": 4,
+				"_end_at": "2014-09-01T00:00:00+00:00",
+				"_start_at": "2014-09-01T00:00:00+00:00",
+				"searchUniques:sum": 71
+			}
+		]
+	},
+	{
+		"pagePath": "/tax-disc/page2",
+		"values": [
+			{
+				"_count": 4,
+				"_end_at": "2014-09-02T00:00:00+00:00",
+				"_start_at": "2014-09-01T00:00:00+00:00",
+				"searchUniques:sum": 75
+			}
+		]
+	}
+]
+}`)(w, r)
+						} else {
+							ghttp.RespondWith(http.StatusOK, `
+{
+"data": [
+  {
+    "_count": 8,
+    "_group_count": 8,
+    "searchKeyword": "employer access",
+    "searchUniques:sum": 126,
+    "values": [{
+      "_count": 1,
+      "searchUniques:sum": 126,
+      "_end_at": "2014-09-02T00:00:00+00:00",
+      "_start_at": "2014-09-01T00:00:00+00:00"
+    }]
+  },
+  {
+    "_count": 3,
+    "_group_count": 3,
+    "searchKeyword": "pupil premium",
+    "searchUniques:sum": 45,
+    "values": [{
+      "_count": 1,
+      "searchUniques:sum": 45,
+      "_end_at": "2014-09-02T00:00:00+00:00",
+      "_start_at": "2014-09-01T00:00:00+00:00"
+    }]
+  },
+  {
+    "_count": 4,
+    "_group_count": 4,
+    "searchKeyword": "s2s",
+    "searchUniques:sum": 104,
+    "values": [{
+      "_count": 1,
+      "searchUniques:sum": 104,
+      "_end_at": "2014-09-02T00:00:00+00:00",
+      "_start_at": "2014-09-03T00:00:00+00:00"
+    }]
+  }
+]
+}`)(w, r)
+						}
+					})))
+
+			server.RouteToHandler("GET", "/data/govuk-info/page-contacts",
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest("GET", "/data/govuk-info/page-contacts"),
+					ghttp.RespondWith(http.StatusOK, `
+{
+"data": [
+	{
+		"pagePath": "/tax-disc",
+		"values": [
+			{
+				"_count": 4,
+				"_end_at": "2014-09-03T00:00:00+00:00",
+				"_start_at": "2014-09-02T00:00:00+00:00",
+				"total:sum": 71
+			}
+		]
+	},
+	{
+		"pagePath": "/tax-disc/page2",
+		"values": [
+			{
+				"_count": 4,
+				"_end_at": "2014-09-03T00:00:00+00:00",
+				"_start_at": "2014-09-02T00:00:00+00:00",
+				"total:sum": 73
+			}
+		]
+	}
+]
+}`)))
+
+			statistics, err := SlugStatistics(client, "/foo", true)
+			Expect(err).To(BeNil())
+			Expect(statistics).ToNot(BeNil())
+			Expect(len(statistics.PageViews)).To(Equal(2))
+			Expect(len(statistics.Searches)).To(Equal(2))
+			Expect(len(statistics.SearchTerms)).To(Equal(3))
+			Expect(len(statistics.ProblemReports)).To(Equal(2))
+			Expect(statistics.PageViews[1].Value).To(Equal(25735))
+			Expect(statistics.PageViews[1].Path).To(Equal("/tax-disc/page2"))
+			Expect(statistics.Searches[1].Value).To(Equal(75))
+			Expect(statistics.Searches[1].Path).To(Equal("/tax-disc/page2"))
+			Expect(statistics.ProblemReports[1].Value).To(Equal(73))
+			Expect(statistics.ProblemReports[1].Path).To(Equal("/tax-disc/page2"))
+
+			pageViewTimestamp, err := time.Parse(time.RFC3339, "2014-07-02T00:00:00+00:00")
+			Expect(err).To(BeNil())
+			Expect(statistics.PageViews[1].Timestamp).
+				To(Equal(pageViewTimestamp))
+
+			searchesTimestamp, err := time.Parse(time.RFC3339, "2014-09-01T00:00:00+00:00")
+			Expect(err).To(BeNil())
+			Expect(statistics.Searches[0].Timestamp).
+				To(Equal(searchesTimestamp))
+		})
+
+
 	})
 
 })


### PR DESCRIPTION
Please don't review this unless you are @benilovj!

Update metadata-api to return data for multi-part formats like detailed guides. 

May need more tests - TBC.