### PR TITLE
Treat smart answers as multipart formats.

### DIFF
--- a/main.go
+++ b/main.go
@@ -77,7 +77,7 @@ func InfoHandler(contentAPI, needAPI, performanceAPI string, config *Config) fun
 
 		performanceStart := time.Now()
 		ppClient := performanceclient.NewDataClient(performanceAPI, logging)
-		is_multipart := (len(artefact.Details.Parts) != 0)
+		is_multipart := (len(artefact.Details.Parts) != 0) || (artefact.Format == "smart-answer")
 		performance, err := performance_platform.SlugStatistics(ppClient, slug, is_multipart)
 		statsDTiming("performance", performanceStart, time.Now())
 		if err != nil {


### PR DESCRIPTION
This will return PP statistics filtered by prefix, not by slug. In other
words, return all the results for all the paths through a smart answer.

We already do this for multipart formats like guides.

This won't affect anything displayed in info-frontend for the moment.