### PR TITLE
Create aggregate statistics about info pages.

### DIFF
--- a/calculate_statistics/README.md
+++ b/calculate_statistics/README.md
@@ -1,0 +1,35 @@
+Work in progress!
+
+Script to load aggregate statistics for info pages into the Performance
+Platform's /info-statistics dataset.
+
+This will be queried by metadata-api and returned to /info pages, in order
+to put the numbers displayed on those pages into context.
+
+It could also be used to power a dashboard of the pages with the most
+searches, most problem reports etc.
+
+Instructions
+------------
+
+Before loading the data, add the token for the PP dataset to your settings.
+(NB: this should be replaced by an environment variable from `pp-puppet`.)
+
+Install the dependencies (you may want to do this inside a virtualenv):
+
+    pip install -r requirements.txt
+
+NB: This should eventually be done in the project makefile.
+
+Run the script to load data:
+
+    python main.py
+
+Testing
+-------
+
+Run tests:
+
+    python test.py
+
+NB: These should eventually be added to the project makefile.

--- a/calculate_statistics/info_statistics.py
+++ b/calculate_statistics/info_statistics.py
@@ -1,0 +1,242 @@
+import io
+import json
+import os
+import requests
+import settings
+import string
+from datetime import datetime, timedelta
+from performanceplatform.client import DataSet
+
+'''
+InfoStatistics class: this generates the aggregated data for
+the PP's info-statistics dataset. This is used to identify
+pages with high numbers of problem reports and searches.
+It does the following:
+- Fetches data from the PP for all pages with problem reports
+  or searches
+- Aggregates problem reports for smart answers to the level of
+  the starting URL, to aid comparison
+- Initialises a neat output dataset
+- For all URLs with problem reports or searches, fetches data
+  on the number of unique page views
+- Normalise problem reports / searches by the number of unique
+  page views
+- Write output to a local JSON file and to the PP
+'''
+
+
+class InfoStatistics():
+
+    date_format = "%Y-%m-%dT00:00:00Z"
+    date_format_longer = "%Y-%m-%dT00:00:00+00:00"
+
+    def __init__(self, pp_token):
+        self.end_date = datetime.now()
+        self.start_date = self.end_date - timedelta(days=settings.DAYS)
+        self.pp_token = pp_token
+
+    def construct_pp_query(self, dataset, value,
+                           filter_by=None, filter_by_prefix=None):
+        '''
+        Construct the PP URL to request.
+        '''
+        query = dataset
+        query += '?group_by=pagePath&period=day'
+        query += '&start_at=%s' % self.start_date.strftime(self.date_format)
+        query += '&end_at=%s' % self.end_date.strftime(self.date_format)
+        query += '&collect=%s' % value
+        if filter_by:
+            query += '&filter_by=pagePath:%s' % filter_by
+        elif filter_by_prefix:
+            query += '&filter_by_prefix=pagePath:%s' % filter_by_prefix
+        return query
+
+    def get_pp_data(self, query):
+        '''
+        Make PP call.
+        '''
+        results = []
+        url = "%s/%s/%s" % (settings.DATA_DOMAIN, settings.DATA_GROUP, query)
+        try:
+            r = requests.get(url)
+            if r.status_code == 200:
+                json_data = r.json()
+                if 'data' in json_data:
+                    return json_data['data']
+            else:
+                print r.status_code, url
+        except requests.exceptions.ConnectionError, requests.exceptions.HTTPError:
+            print 'ERROR', url
+        return []
+
+    def get_smart_answer_urls(self):
+        '''
+        Get all smart answers, from the Search API.
+        '''
+        smart_answers = []
+        url = 'https://www.gov.uk/api/search.json?filter_format=smart-answer'
+        url += '&start=0&count=1000&fields=link'
+        try:
+            r = requests.get(url)
+            if r.status_code == 200:
+                json_data = r.json()
+                if 'results' in json_data:
+                    for l in json_data['results']:
+                        smart_answers.append(l['link'])
+        except requests.exceptions.ConnectionError, requests.exceptions.HTTPError:
+            print 'ERROR', url
+
+        return smart_answers
+
+    def tidy_smart_answers(self, smart_answers, results):
+        '''
+        Sum page contacts values for smart answers, then
+        remove non-root smart answers URLs.
+        '''
+        smart_answer_totals = {}
+        for s in smart_answers:
+            smart_answer_totals[s] = 0
+        for r in results:
+            for s in smart_answers:
+                if 'total:sum' in r and r['pagePath'].startswith(s):
+                    smart_answer_totals[s] += r['total:sum']
+
+        for r in results:
+            for s in smart_answer_totals:
+                if r['pagePath'] in s and 'total:sum' in r:
+                    r['total:sum'] = smart_answer_totals[s]
+
+        for result in results[:]:
+            path = result.get("pagePath")
+            if "total:sum" in result and any(path.startswith(sa) and path != sa for sa in smart_answers):
+                results.remove(result)
+
+        return results
+
+    def get_unique_urls(self, results):
+        '''
+        Return the unique URLs in the results from the
+        first two datasets.
+        '''
+        urls = []
+        for r in results:
+            if r['pagePath'] not in urls:
+                urls.append(r['pagePath'])
+        return urls
+
+    def initialise_results(self, urls):
+        '''
+        For our set of unique URLs, initialise the data we will send
+        to the PP: it needs certain datefields.
+        '''
+        output = []
+        fields = ['uniquePageviews', 'problemReports',
+                  'problemsPer100kViews', 'problemsNormalised',
+                  'searchUniques', 'searchesPer100kViews',
+                  'searchesNormalised']
+        for url in urls:
+            r = {}
+            r['pagePath'] = url
+            r['_timestamp'] = self.start_date.strftime(self.date_format)
+            r['_start_at'] = self.start_date.strftime(self.date_format)
+            r['_end_at'] = self.end_date.strftime(self.date_format)
+            for f in fields:
+                r[f] = None
+            output.append(r)
+        return output
+
+    def combine_dataset_results(self, output, results):
+        '''
+        Combine the results from the page-contacts and
+        search-terms datasets into one.
+        '''
+        for r in results:
+            for o in output:
+                if o['pagePath'] == r['pagePath']:
+                    if 'total:sum' in r:
+                        o['problemReports'] = r['total:sum']
+                    if 'searchUniques:sum' in r:
+                        o['searchUniques'] = r['searchUniques:sum']
+        return output
+
+    def calculate_normalised_values(self, output):
+        '''
+        Calculate problem reports + searches per 100k views.
+        Ignore pages with more problem reports than page views,
+        as a primitive spam filter.
+        Also calculate a normalised value.
+        '''
+        for r in output:
+            if r['problemReports'] and r['uniquePageviews']:
+                raw = r['problemReports'] / r['uniquePageviews']
+                if r['problemReports'] > 2 and (r['problemReports'] < r['uniquePageviews']):
+                    r['problemsPer100kViews'] = raw * 100000
+                    r['problemsNormalised'] = r['problemsPer100kViews'] * r['problemReports']
+            if r['searchUniques'] and r['uniquePageviews']:
+                raw = r['searchUniques'] / r['uniquePageviews']
+                if r['searchUniques'] > 3:
+                    r['searchesPer100kViews'] = raw * 100000
+                    r['searchesNormalised'] = r['searchesPer100kViews'] * r['searchUniques']
+        return output
+
+    def process_data(self):
+        '''
+        Main function.
+        '''
+
+        print 'Fetching PP data on problems and searches...'
+        results = []
+        for s in string.lowercase:
+            query = self.construct_pp_query('page-contacts', 'total:sum',
+                                            filter_by=None,
+                                            filter_by_prefix='/%s' % s)
+            results += self.get_pp_data(query)
+            query = self.construct_pp_query('search-terms',
+                                            'searchUniques:sum',
+                                            filter_by=None,
+                                            filter_by_prefix='/%s' % s)
+            results += self.get_pp_data(query)
+
+        # Tidy up results for smart answers.
+        # It would be nice to amend how Feedex sends results to the PP
+        # so that this step isn't necessary.
+        print 'Tidying problem data for smart answers...'
+        smart_answers = self.get_smart_answer_urls()
+        results = self.tidy_smart_answers(smart_answers, results)
+
+        print 'Initialising results...'
+        urls = self.get_unique_urls(results)
+        output = self.initialise_results(urls)
+        output = self.combine_dataset_results(output, results)
+
+        # For each URL, get page-statistics results from the PP.
+        print 'Getting page view data per URL...'
+        for o in output:
+            query = self.construct_pp_query('page-statistics',
+                                            'uniquePageviews:sum',
+                                            filter_by=o['pagePath'])
+            d = self.get_pp_data(query)
+            if d and d[0]['uniquePageviews:sum']:
+                o['uniquePageviews'] = int(d[0]['uniquePageviews:sum'])
+
+        # Calculate normalised values.
+        print 'Normalising values...'
+        output = self.calculate_normalised_values(output)
+
+        # Dump results to a local JSON file.
+        # This stores results in case posting fails: it also
+        # gives us a historical archive of results.
+        # TODO: Discuss whether this is useful/necessary.
+        print 'Writing to local file...'
+        fname = './results/data-%s.json' % self.end_date.strftime("%Y-%m-%d")
+        with io.open(fname, 'w', encoding='utf-8') as f:
+            f.write(unicode(json.dumps(output, indent=2, sort_keys=True)))
+
+        # Empty PP dataset, then post new results.
+        # TODO: Error handling: not sure how the Python library does this?
+        print 'Posting data to PP...'
+        data_set = DataSet.from_group_and_type(settings.DATA_DOMAIN,
+                                               settings.DATA_GROUP,
+                                               settings.RESULTS_DATASET,
+                                               token=self.pp_token)
+        data_set.post(output)

--- a/calculate_statistics/main.py
+++ b/calculate_statistics/main.py
@@ -1,0 +1,13 @@
+import os
+import info_statistics
+import settings
+
+if 'PP_DATASET_TOKEN' not in os.environ:
+    msg = 'You need to set the dataset token for the PP '
+    msg += '%s/%s ' % (settings.DATA_GROUP, settings.RESULTS_DATASET)
+    msg += 'dataset to run this script. You can get this from '
+    msg += 'https://stagecraft.production.performance.service.gov.uk/admin/'
+    print msg
+else:
+    c = info_statistics.InfoStatistics(os.environ['PP_DATASET_TOKEN'])
+    c.process_data()

--- a/calculate_statistics/requirements.txt
+++ b/calculate_statistics/requirements.txt
@@ -1,0 +1,1 @@
+performanceplatform-client>=0.6.0

--- a/calculate_statistics/settings.py
+++ b/calculate_statistics/settings.py
@@ -1,0 +1,4 @@
+DATA_DOMAIN = 'https://www.performance.service.gov.uk/data'
+DATA_GROUP = 'govuk-info'
+RESULTS_DATASET = 'info-statistics'
+DAYS = 42

--- a/calculate_statistics/test.py
+++ b/calculate_statistics/test.py
@@ -1,0 +1,180 @@
+import unittest
+from datetime import datetime
+import settings
+from info_statistics import InfoStatistics
+
+
+class TestInfoStatistics(unittest.TestCase):
+
+    def testConstructPPQuery(self):
+        """construct_pp_query should return expected querystring"""
+        dataset = 'page-contacts'
+        value = 'total:sum'
+        search_term = 'aa'
+        query = info.construct_pp_query(dataset, value, search_term)
+        d = 'page-contacts?group_by=pagePath&period=day'
+        d += '&start_at=2014-12-16T00:00:00Z'
+        d += '&end_at=2015-01-27T00:00:00Z'
+        d += '&collect=total:sum&filter_by=pagePath:aa'
+        self.assertEqual(query, d)
+        query = info.construct_pp_query(dataset, value, filter_by=None,
+                                        filter_by_prefix=search_term)
+        d = 'page-contacts?group_by=pagePath&period=day'
+        d += '&start_at=2014-12-16T00:00:00Z'
+        d += '&end_at=2015-01-27T00:00:00Z'
+        d += '&collect=total:sum&filter_by_prefix=pagePath:aa'
+        self.assertEqual(query, d)
+
+    def testTidySmartAnswers(self):
+        """tidy_smart_answers should take an array of raw data
+        results from the PP, and for all URLs that are smart answers,
+        it should sum the number of problem reports and remove
+         all entries except those for root URLs"""
+        smart_answers = [u'/calculate-state-pension', u'/check-uk-visa']
+        data = [
+            {
+                "pagePath": "/check-uk-visa",
+                "total:sum": 2.0
+            },
+            {
+                "pagePath": "/check-uk-visa/y",
+                "total:sum": 3.0
+            },
+            {
+                "pagePath": "/check-uk-visa/n",
+                "total:sum": 4.0
+            },
+            {
+                "pagePath": "/bank-holidays",
+                "total:sum": 2.0
+            },
+            {
+                "pagePath": "/check-uk-visa",
+                "searchUniques:sum": 2.0
+            }
+        ]
+        results = info.tidy_smart_answers(smart_answers, data)
+        self.assertEqual(len(results), 3)
+        self.assertEqual(results[0]['pagePath'], "/check-uk-visa")
+        self.assertEqual(results[0]['total:sum'], 9.0)
+        self.assertEqual(results[1]['pagePath'], "/bank-holidays")
+        self.assertEqual(results[1]['total:sum'], 2.0)
+        self.assertEqual(results[2]['pagePath'], "/check-uk-visa")
+        self.assertEqual(results[2]['searchUniques:sum'], 2.0)
+
+    def testGetUniqueURLs(self):
+        """get_unique_urls should return a list of unique urls
+        from an input dataset"""
+        data = [
+            {
+                "pagePath": "/driving-licence-fees",
+                "total:sum": 10.0
+            },
+            {
+                "pagePath": "/driving-licence-fees/y",
+                "total:sum": 10.0
+            },
+            {
+                "pagePath": "/driving-licence-fees",
+                "total:sum": 10.0
+            }]
+        results = info.get_unique_urls(data)
+        expected = ["/driving-licence-fees", "/driving-licence-fees/y"]
+        self.assertEqual(results, expected)
+
+    def testInitialiseResults(self):
+        """initialise_results should take a list of URLs and
+        return an initialised set of results"""
+        urls = ['/dartford-crossing',
+                '/dartford-crossing-fees',
+                '/dartford-crossing-fees-exemptions-penalties']
+        results = info.initialise_results(urls)
+        self.assertEqual(len(results), 3)
+        self.assertEqual(results[0]['pagePath'], '/dartford-crossing')
+        self.assertEqual(results[0]['_start_at'], '2014-12-16T00:00:00Z')
+        self.assertEqual(results[0]['_timestamp'], '2014-12-16T00:00:00Z')
+        self.assertEqual(results[0]['_end_at'], '2015-01-27T00:00:00Z')
+        self.assertEqual(results[0]['searchUniques'], None)
+        self.assertEqual(results[0]['searchesNormalised'], None)
+
+    def testCombineDatasetResults(self):
+        """combine_dataset_results should take an initialised
+        set of results, and our raw data from the PP, and combine
+        results from the raw data into a tidy set of output"""
+        results = [
+            {
+                "pagePath": "/check-uk-visa",
+                "total:sum": 9.0
+            },
+            {
+                "pagePath": "/check-uk-visa",
+                "searchUniques:sum": 2.0
+            },
+            {
+                "pagePath": "/bank-holidays",
+                "total:sum": 2.0
+            }
+        ]
+        output = [
+            {
+                "pagePath": "/check-uk-visa",
+                "problemReports": None,
+                "searchUniques": None
+            },
+            {
+                "pagePath": "/bank-holidays",
+                "problemReports": None,
+                "searchUniques": None
+            }
+        ]
+        actual = info.combine_dataset_results(output, results)
+        self.assertEqual(actual[0]['pagePath'], "/check-uk-visa")
+        self.assertEqual(actual[0]['problemReports'], 9.0)
+        self.assertEqual(actual[0]['searchUniques'], 2.0)
+        self.assertEqual(actual[1]['pagePath'], "/bank-holidays")
+        self.assertEqual(actual[1]['problemReports'], 2.0)
+        self.assertEqual(actual[1]['searchUniques'], None)
+
+    def testCalculateNormalisedValues(self):
+        """calculate_normalise_values should return problems and searches
+        per 100k page views, and normalised results, and deal with
+        null values """
+        data = [
+            {
+                'pagePath': u'/calculate-state-pension',
+                'problemReports': 469.0,
+                'searchUniques': 930.0,
+                'uniquePageviews': 10000.0,
+                'problemsPer100kViews': None,
+                'problemsNormalised': None,
+                'searchesPer100kViews': None,
+                'searchesNormalised': None
+
+            },
+            {
+                'pagePath': u'/calculate-employee-redundancy-pay',
+                'problemReports': 20.0,
+                'searchUniques': None,
+                'uniquePageviews': None,
+                'problemsPer100kViews': None,
+                'problemsNormalised': None,
+                'searchesPer100kViews': None,
+                'searchesNormalised': None
+            }
+        ]
+        results = info.calculate_normalised_values(data)
+        self.assertEqual(results[0]['problemsPer100kViews'], 4690.0)
+        self.assertEqual(results[0]['problemsNormalised'], 2199610.0)
+        self.assertEqual(results[0]['searchesPer100kViews'], 9300.0)
+        self.assertEqual(results[0]['searchesNormalised'], 8649000.0)
+        self.assertEqual(results[1]['problemsPer100kViews'], None)
+        self.assertEqual(results[1]['problemsNormalised'], None)
+        self.assertEqual(results[1]['searchesPer100kViews'], None)
+        self.assertEqual(results[1]['searchesNormalised'], None)
+
+
+if __name__ == "__main__":
+    info = InfoStatistics('foo')
+    info.start_date = datetime.strptime("2014-12-16", "%Y-%m-%d").date()
+    info.end_date = datetime.strptime("2015-01-27", "%Y-%m-%d").date()
+    unittest.main()


### PR DESCRIPTION
Gather PP data on all pages with problem reports or search
queries. Aggregate and normalise this data by the number of
unique page views for each page. Push the aggregated data
back to the PP.

This should eventually be run as a regular job, perhaps once
a week. We will then be able to generate regular reports
for the content team, helping them to fix problematic pages.

Has some code to deal with smart answers, including a 
call to the GOV.UK search API to get URLs. This is
because the `page-statistics` and `search-terms` datasets 
aggregate page view and search term statistics across
all pages in a smart answer, but `page-contacts` reports
problem reports separately for each page. 

Longer-term it would be good to make this consistent at 
the point where the data is pushed into the PP - that would 
also simplify how we handle smart answers in info-frontend.

We need to discuss how often, and where, to run the regular
job to gather these statistics: I haven't added anything
to do this yet. Nor have I added setup for this code into
the main Makefile.