### PR TITLE
Expose the Need status attribute

### DIFF
--- a/fixtures/need_api_response.json
+++ b/fixtures/need_api_response.json
@@ -25,5 +25,8 @@
   "yearly_searches": null,
   "other_evidence": null,
   "legislation": null,
-  "duplicate_of": null
+  "duplicate_of": null,
+  "status": {
+    "description": "valid"
+  }
 }

--- a/need_api/need.go
+++ b/need_api/need.go
@@ -15,6 +15,10 @@ type Organisation struct {
 	ChildIDs     []string `json:"child_ids"`
 }
 
+type NeedStatus struct {
+	Description  string   `json:"description"`
+}
+
 type Need struct {
 	ID                 int            `json:"id"`
 	Role               string         `json:"role"`
@@ -33,6 +37,7 @@ type Need struct {
 	Legislation        string         `json:"legislation"`
 	AllOrganisations   bool           `json:"applies_to_all_organisations"`
 	DuplicateOf        int            `json:"duplicate_of"`
+	Status             *NeedStatus    `json:"status"`
 }
 
 func ParseNeedResponse(response []byte) (*Need, error) {

--- a/need_api/need_test.go
+++ b/need_api/need_test.go
@@ -43,7 +43,10 @@ var _ = Describe("Need", func() {
     "yearly_searches": null,
     "other_evidence": null,
     "legislation": null,
-    "duplicate_of": null
+    "duplicate_of": null,
+    "status": {
+      "description": "valid"
+    }
 }`
 
 			need, err := ParseNeedResponse([]byte(exampleNeedApiResponse))
@@ -65,6 +68,9 @@ var _ = Describe("Need", func() {
 					},
 				},
 				Justifications: []string{"This is a test need"},
+				Status:          &NeedStatus{
+					Description:   "valid",
+				},
 			}))
 		})
 	})


### PR DESCRIPTION
A `status` field has been [recently introduced into the Need API](https://github.com/alphagov/govuk_need_api/pull/76). This status 
can be "valid", "valid with conditions" or "not valid". Since we want
to only publish needs that are valid on the 'info' pages, the Metadata API
should expose this field for the `info-frontend` to use.