### PR TITLE
Remove fields that have been removed from Need API

### DIFF
--- a/fixtures/need_api_response.json
+++ b/fixtures/need_api_response.json
@@ -25,7 +25,5 @@
   "yearly_searches": null,
   "other_evidence": null,
   "legislation": null,
-  "in_scope": null,
-  "out_of_scope_reason": null,
   "duplicate_of": null
 }

--- a/need_api/need.go
+++ b/need_api/need.go
@@ -32,8 +32,6 @@ type Need struct {
 	OtherEvidence      string         `json:"other_evidence"`
 	Legislation        string         `json:"legislation"`
 	AllOrganisations   bool           `json:"applies_to_all_organisations"`
-	InScope            bool           `json:"in_scope"`
-	OutOfScopeReason   string         `json:"out_of_scope_reason"`
 	DuplicateOf        int            `json:"duplicate_of"`
 }
 

--- a/need_api/need_test.go
+++ b/need_api/need_test.go
@@ -43,8 +43,6 @@ var _ = Describe("Need", func() {
     "yearly_searches": null,
     "other_evidence": null,
     "legislation": null,
-    "in_scope": null,
-    "out_of_scope_reason": null,
     "duplicate_of": null
 }`
 


### PR DESCRIPTION
The `in_scope` and `out_of_scope_reason` have been [removed from the Need API](https://github.com/alphagov/govuk_need_api/pull/78).