### PR TITLE
Use SPDY

### DIFF
--- a/Gomfile
+++ b/Gomfile
@@ -1,5 +1,6 @@
-gom 'github.com/alphagov/performanceplatform-client.go', :commit => '6b388883f3e3cf2a864aeb335ce36e10f0e7a60d'
+gom 'github.com/alphagov/performanceplatform-client.go', :commit => 'cf5645ec19680fed098ce5c304ac238e52eb75e8'
 gom 'github.com/Sirupsen/logrus', :commit => '965349de21e7b1e9e80b6ae02e093f1522516ef3'
+gom 'github.com/jabley/spdy', :commit => '29d3ccc45a126c1e1aecb23025622759e8a0d942'
 gom 'github.com/codegangsta/negroni', :commit => 'c64702ca03d0f858ab7866638b69e85f0d4c6ee7'
 gom 'github.com/google/go-querystring/query', :commit => '30f7a39f4a218feb5325f3aebc60c32a572a8274'
 gom 'github.com/jinzhu/now', :commit => 'caef738a54cb159a5fe083e01609bc6873a84501'

--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/Sirupsen/logrus"
+	"github.com/jabley/spdy"
 	"github.com/alphagov/performanceplatform-client.go"
 	"github.com/codegangsta/negroni"
 	"github.com/meatballhat/negroni-logrus"
@@ -97,6 +98,7 @@ func InfoHandler(contentAPI, needAPI, performanceAPI string, config *Config) fun
 }
 
 func main() {
+	http.DefaultClient = &http.Client{Transport: &spdy.Transport{}}
 	config, err := ReadConfig("config.json")
 	if err != nil {
 		logging.Fatalln("Couldn't load configuration", err)


### PR DESCRIPTION
The Performance Platform SSL endpoints support SPDY. Using this gives
a minor performance benefit by using the network more efficiently.

This works by using the version of performanceplatform-client-go which
uses the net/http/#DefaultClient, and using a SPDY library which
replaces the default client with one which uses a Transport that
supports SPDY.