### PR TITLE
Add timeouts to calls to upstream services

### DIFF
--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"net/http"
 	"os"
+	"strconv"
 	"time"
 
 	"github.com/Sirupsen/logrus"
@@ -21,6 +22,7 @@ import (
 var (
 	appDomain    = getEnvDefault("GOVUK_APP_DOMAIN", "alphagov.co.uk")
 	port         = getEnvDefault("HTTP_PORT", "3000")
+	timeout      = getEnvDefault("HTTP_TIMEOUT", "2000")
 	httpProtocol = getHttpProtocol(appDomain)
 
 	contentAPI     = httpProtocol + "://contentapi." + appDomain
@@ -102,6 +104,12 @@ func main() {
 		logging.Fatalln("Couldn't load configuration", err)
 	}
 
+	i, err := strconv.Atoi(timeout)
+	if err != nil {
+		logging.Fatalln("Timeout wasn't an integer of milliseconds")
+	}
+
+	http.DefaultClient.Timeout = time.Duration(i) * time.Millisecond
 	httpMux := http.NewServeMux()
 	httpMux.HandleFunc("/healthcheck", HealthCheckHandler)
 	httpMux.HandleFunc("/info/", InfoHandler(

--- a/request/request.go
+++ b/request/request.go
@@ -12,8 +12,6 @@ var (
 )
 
 func NewRequest(url, bearerToken string) (*http.Response, error) {
-	client := &http.Client{}
-
 	request, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		return nil, err
@@ -22,7 +20,7 @@ func NewRequest(url, bearerToken string) (*http.Response, error) {
 	request.Header.Add("Authorization", "Bearer "+bearerToken)
 	request.Header.Add("Accept", "application/json")
 
-	response, err := client.Do(request)
+	response, err := http.DefaultClient.Do(request)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Use the http.DefaultClient to talk to things, rather than more than one
client.

This means that the connections to the Need API, Content API and
Performance Platform will all be using the same http.Client instance.
Previously, the Performance Platform was using the DefaultClient, and a
separate instance was being used to talk to the other two.

Change the timeout to be 2 seconds for a response from upstream, rather
than the default of 30 seconds.