### PR TITLE
Read bearer token config from env

### DIFF
--- a/config.go
+++ b/config.go
@@ -1,33 +1,17 @@
 package main
 
 import (
-	"encoding/json"
-	"io/ioutil"
 	"os"
-	"path/filepath"
 )
 
 type Config struct {
-	BearerTokenContentAPI string `json:"bearer_token_content_api"`
-	BearerTokenNeedAPI    string `json:"bearer_token_need_api"`
+	BearerTokenContentAPI string
+	BearerTokenNeedAPI    string
 }
 
-func ReadConfig(filename string) (*Config, error) {
-	workingDirectory, err := filepath.Abs(filepath.Dir(os.Args[0]))
-	if err != nil {
-		return nil, err
+func InitConfig() *Config {
+	return &Config{
+		BearerTokenContentAPI: os.Getenv("CONTENT_API_BEARER_TOKEN"),
+		BearerTokenNeedAPI:    os.Getenv("NEED_API_BEARER_TOKEN"),
 	}
-
-	configPath := workingDirectory + "/" + filename
-	file, err := ioutil.ReadFile(configPath)
-	if err != nil {
-		return nil, err
-	}
-
-	config := &Config{}
-	if err := json.Unmarshal(file, &config); err != nil {
-		return nil, err
-	}
-
-	return config, nil
 }

--- a/config_test.go
+++ b/config_test.go
@@ -1,9 +1,7 @@
 package main_test
 
 import (
-	"io/ioutil"
 	"os"
-	"path/filepath"
 
 	. "github.com/alphagov/metadata-api"
 
@@ -12,22 +10,19 @@ import (
 )
 
 var _ = Describe("Config", func() {
-	Describe("ReadConfig", func() {
+	Describe("InitConfig", func() {
 		It("can read and parse a config file from the path", func() {
-			configFile := "test_config.json"
-			configData := `{"bearer_token_content_api": "foo", "bearer_token_need_api": "bar"}`
+			os.Setenv("CONTENT_API_BEARER_TOKEN", "foo")
+			os.Setenv("NEED_API_BEARER_TOKEN", "bar")
 
-			workingDirectory, _ := filepath.Abs(filepath.Dir(os.Args[0]))
-
-			err := ioutil.WriteFile(workingDirectory+"/"+configFile, []byte(configData), 0644)
-			Expect(err).To(BeNil())
-
-			config, err := ReadConfig(configFile)
-			Expect(err).To(BeNil())
+			config := InitConfig()
 			Expect(config).To(Equal(&Config{
 				BearerTokenContentAPI: "foo",
 				BearerTokenNeedAPI:    "bar",
 			}))
+
+			os.Unsetenv("CONTENT_API_BEARER_TOKEN")
+			os.Unsetenv("NEED_API_BEARER_TOKEN")
 		})
 	})
 })

--- a/main.go
+++ b/main.go
@@ -104,10 +104,7 @@ func InfoHandler(contentAPI, needAPI, performanceAPI string,
 }
 
 func main() {
-	config, err := ReadConfig("config.json")
-	if err != nil {
-		logging.Fatalln("Couldn't load configuration", err)
-	}
+	config := InitConfig()
 
 	httpMux := http.NewServeMux()
 	httpMux.HandleFunc("/healthcheck", HealthCheckHandler)


### PR DESCRIPTION
Part of https://trello.com/c/BrKRdn4f/495-rebuild-gov-uk-app-deployment-pipeline

We're moving the deployment config for this app, the content/need API bearer tokens should be stored in ENV vars.

Depends on https://github.com/alphagov/govuk-puppet/pull/5098