### PR TITLE
Update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,5 @@ within `.envrc` in the `metadata-api` root.
 
 ## Configuration
 
-Most configuration can be handled using `ENV` variables that get
-passed into the process. However the `BEARER_TOKEN` values for both
-the Content API and the Need API are provided using a JSON file in the
-working directory of the process. See `config.json` for an example of
-this file.
+Configuration can be handled using `ENV` variables that get
+passed into the process.

--- a/config.json
+++ b/config.json
@@ -1,4 +1,0 @@
-{
-  "bearer_token_content_api": "foo",
-  "bearer_token_need_api": "bar"
-}


### PR DESCRIPTION
How we configure bearer tokens for the content API and need API has recently changed so update the readme and remove example JSON config.