### PR TITLE
Build clarification for new ci

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ _testmain.go
 _vendor
 metadata-api
 test_config.json
+__build

--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,17 @@
-.PHONY: deps test build
+.PHONY: build run test clean
 
-all: test build
+BINARY ?= $(PWD)/metadata-api
 
-test:
-	go test -v $$(go list ./... | grep -v '/vendor/')
-
-build:
-	go build -o metadata-api
-
-run: build
-	./metadata-api
+all: clean build test
 
 clean:
-	rm -rf bin metadata-api
+	rm -rf $(BINARY)
+
+build:
+	go build -o $(BINARY)
+
+test: build
+	go test -race -v $$(go list ./... | grep -v '/vendor/')
+
+run: build
+	$(BINARY)

--- a/jenkins.sh
+++ b/jenkins.sh
@@ -1,14 +1,33 @@
 #!/bin/bash
-set -e
+set -x
+set -eu
 
-REPO=alphagov/metadata-api
-export GOPATH=$PWD/gopath
-GO_GITHUB_PATH=$GOPATH/src/github.com
-BUILD_PATH=$GO_GITHUB_PATH/$REPO
+# The repository owner and name
+REPO="alphagov/metadata-api"
+# The name of the binary to output
+BINARY=$(basename "$REPO")
 
-rm -rf $GOPATH && mkdir -p $GOPATH/bin $BUILD_PATH
+# Define the Jenkins workspace root in case we're not running through Jenkins
+: ${WORKSPACE:=$PWD}
 
-rsync -a ./ $BUILD_PATH --exclude=gopath
+# Go projects need to be built from with a Go workspace, which is a directory
+# tree with a specific format.  The default checkout path isn't enough, so we
+# need to create that workspace and build from within there.  The GOPATH
+# envionment variable points to the location of the workspace.
+#
+# See https://golang.org/doc/code.html#Workspaces for more details.
+BUILD_DIR="__build"
+export GOPATH="$WORKSPACE/$BUILD_DIR"
 
-cd $BUILD_PATH && make
-cp ./metadata-api $WORKSPACE/metadata-api
+# Define the location within the GOPATH that the source should reside
+SRC_PATH="$GOPATH/src/github.com/$REPO"
+
+# Recreate the GOPATH workspace from scratch
+rm -rf "$GOPATH" && mkdir -p "$GOPATH/bin" "$SRC_PATH"
+
+# Copy the whole repo content into the build tree
+rsync -a ./ "$SRC_PATH" --exclude="$BUILD_DIR"
+
+# Move in to the source path, then build the binary into the Jenkins workspace
+# root (for later packaging) and run the tests
+(cd "$SRC_PATH" && BINARY="$WORKSPACE/$BINARY" make clean build test)


### PR DESCRIPTION
https://trello.com/c/kLrX1PqG/580-move-metadata-api-to-new-ci-infrastructure-1

This brings the the build scripts in line with [other Go applications](https://github.com/alphagov/router/blob/master/Makefile) makes the tests prettier in CI and builds to a sensible location.